### PR TITLE
Add page timeout parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 
 Diese FastAPI-Anwendung crawlt Websites mit einem Headless-Browser (Playwright) und extrahiert Titel, Text & Bilder.
 
+## API
+
+Der Endpunkt `/crawl-analyze` akzeptiert folgende Query-Parameter:
+
+- `url` (erforderlich): Startadresse der zu crawlenden Website
+- `max_pages` (optional, Standard `5`): Maximale Anzahl von Seiten
+- `min_images` (optional, Standard `10`): Minimale Anzahl an Bildern im Ergebnis
+- `page_timeout` (optional, Standard `30000`): Zeitlimit in Millisekunden pro Seite
+
+Mit `page_timeout` kann das Timeout bei langsamen Seiten erhöht werden.
+
 ## Deploy mit 1 Klick auf Render.com
 
 1. Forke dieses Repository auf GitHub

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 
 Diese FastAPI-Anwendung crawlt Websites mit einem Headless-Browser (Playwright) und extrahiert Titel, Text & Bilder.
 
+## Installation
+
+```bash
+pip install -r requirements.txt
+playwright install
+```
+
 ## API
 
 Der Endpunkt `/crawl-analyze` akzeptiert folgende Query-Parameter:

--- a/main.py
+++ b/main.py
@@ -22,8 +22,17 @@ def is_same_domain(base: str, target: str) -> bool:
 def crawl_analyze(
     url: str = Query(...),
     max_pages: int = Query(5, description="Maximale Anzahl an Seiten"),
-    min_images: int = Query(10, description="Minimale Anzahl an Bildern")
+    min_images: int = Query(10, description="Minimale Anzahl an Bildern"),
+    page_timeout: int = Query(30000, description="Timeout je Seite in Millisekunden")
 ):
+    """Crawlt die angegebene URL und wertet Inhalte aus.
+
+    Args:
+        url: Startadresse der Website.
+        max_pages: Maximale Anzahl von Seiten, die besucht werden.
+        min_images: Mindestanzahl an Bildern im Ergebnis.
+        page_timeout: Zeitlimit für ``page.goto`` in Millisekunden.
+    """
     visited: Set[str] = set()
     to_visit: List[str] = [url]
     all_images: Set[str] = set()
@@ -44,7 +53,7 @@ def crawl_analyze(
             if current_url in visited:
                 continue
             try:
-                page.goto(current_url, timeout=30000)
+                page.goto(current_url, timeout=page_timeout)
                 html = page.content()
                 soup = BeautifulSoup(html, "html.parser")
                 title = soup.title.string.strip() if soup.title else ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 playwright
 beautifulsoup4
+pydantic


### PR DESCRIPTION
## Summary
- add optional `page_timeout` query parameter to `/crawl-analyze`
- use that value in the Playwright `page.goto` call
- document the new parameter in function docstring and README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_6866743fe35c832ab60776ab58a1b2fd